### PR TITLE
WaveBank streaming updated to support Advanced Format (4Kn)

### DIFF
--- a/XAudio2/Common/WAVFileReader.cpp
+++ b/XAudio2/Common/WAVFileReader.cpp
@@ -4,7 +4,6 @@
 // Functions for loading WAV audio files
 //
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License (MIT).
 // Licensed under the MIT License.
 //
 // http://go.microsoft.com/fwlink/?LinkId=248929
@@ -64,8 +63,8 @@ namespace
 
     struct DLSLoop
     {
-        static const uint32_t LOOP_TYPE_FORWARD = 0x00000000;
-        static const uint32_t LOOP_TYPE_RELEASE = 0x00000001;
+        static constexpr uint32_t LOOP_TYPE_FORWARD = 0x00000000;
+        static constexpr uint32_t LOOP_TYPE_RELEASE = 0x00000001;
 
         uint32_t size;
         uint32_t loopType;
@@ -75,8 +74,8 @@ namespace
 
     struct RIFFDLSSample
     {
-        static const uint32_t OPTIONS_NOTRUNCATION = 0x00000001;
-        static const uint32_t OPTIONS_NOCOMPRESSION = 0x00000002;
+        static constexpr uint32_t OPTIONS_NOTRUNCATION = 0x00000001;
+        static constexpr uint32_t OPTIONS_NOCOMPRESSION = 0x00000002;
 
         uint32_t    size;
         uint16_t    unityNote;
@@ -88,9 +87,9 @@ namespace
 
     struct MIDILoop
     {
-        static const uint32_t LOOP_TYPE_FORWARD = 0x00000000;
-        static const uint32_t LOOP_TYPE_ALTERNATING = 0x00000001;
-        static const uint32_t LOOP_TYPE_BACKWARD = 0x00000002;
+        static constexpr uint32_t LOOP_TYPE_FORWARD = 0x00000000;
+        static constexpr uint32_t LOOP_TYPE_ALTERNATING = 0x00000001;
+        static constexpr uint32_t LOOP_TYPE_BACKWARD = 0x00000002;
 
         uint32_t cuePointId;
         uint32_t type;

--- a/XAudio2/Common/WAVFileReader.h
+++ b/XAudio2/Common/WAVFileReader.h
@@ -4,7 +4,6 @@
 // Functions for loading WAV audio files
 //
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License (MIT).
 // Licensed under the MIT License.
 //
 // http://go.microsoft.com/fwlink/?LinkId=248929

--- a/XAudio2/Common/WaveBankReader.cpp
+++ b/XAudio2/Common/WaveBankReader.cpp
@@ -4,7 +4,6 @@
 // Functions for loading audio data from Wave Banks
 //
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License (MIT).
 // Licensed under the MIT License.
 //
 // http://go.microsoft.com/fwlink/?LinkId=248929
@@ -19,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <tuple>
 
 #ifndef MAKEFOURCC
 #define MAKEFOURCC(ch0, ch1, ch2, ch3) \
@@ -61,9 +61,9 @@ namespace
 
     struct HEADER
     {
-        static const uint32_t SIGNATURE = MAKEFOURCC('W', 'B', 'N', 'D');
-        static const uint32_t BE_SIGNATURE = MAKEFOURCC('D', 'N', 'B', 'W');
-        static const uint32_t VERSION = 44;
+        static constexpr uint32_t SIGNATURE = MAKEFOURCC('W', 'B', 'N', 'D');
+        static constexpr uint32_t BE_SIGNATURE = MAKEFOURCC('D', 'N', 'B', 'W');
+        static constexpr uint32_t VERSION = 44;
 
         enum SEGIDX
         {
@@ -85,15 +85,15 @@ namespace
 
     union MINIWAVEFORMAT
     {
-        static const uint32_t TAG_PCM = 0x0;
-        static const uint32_t TAG_XMA = 0x1;
-        static const uint32_t TAG_ADPCM = 0x2;
-        static const uint32_t TAG_WMA = 0x3;
+        static constexpr uint32_t TAG_PCM = 0x0;
+        static constexpr uint32_t TAG_XMA = 0x1;
+        static constexpr uint32_t TAG_ADPCM = 0x2;
+        static constexpr uint32_t TAG_WMA = 0x3;
 
-        static const uint32_t BITDEPTH_8 = 0x0; // PCM only
-        static const uint32_t BITDEPTH_16 = 0x1; // PCM only
+        static constexpr uint32_t BITDEPTH_8 = 0x0; // PCM only
+        static constexpr uint32_t BITDEPTH_16 = 0x1; // PCM only
 
-        static const size_t ADPCM_BLOCKALIGN_CONVERSION_OFFSET = 22;
+        static constexpr size_t ADPCM_BLOCKALIGN_CONVERSION_OFFSET = 22;
 
         struct
         {
@@ -134,7 +134,7 @@ namespace
 
                 case TAG_WMA:
                 {
-                    static const uint32_t aWMABlockAlign[] =
+                    static const uint32_t aWMABlockAlign[17] =
                     {
                         929,
                         1487,
@@ -156,7 +156,7 @@ namespace
                     };
 
                     uint32_t dwBlockAlignIndex = wBlockAlign & 0x1F;
-                    if (dwBlockAlignIndex < _countof(aWMABlockAlign))
+                    if (dwBlockAlignIndex < 17)
                         return aWMABlockAlign[dwBlockAlignIndex];
                 }
                 break;
@@ -184,7 +184,7 @@ namespace
 
                 case TAG_WMA:
                 {
-                    static const uint32_t aWMAAvgBytesPerSec[] =
+                    static const uint32_t aWMAAvgBytesPerSec[7] =
                     {
                         12000,
                         24000,
@@ -197,7 +197,7 @@ namespace
                     // bitrate = entry * 8
 
                     uint32_t dwBytesPerSecIndex = wBlockAlign >> 5;
-                    if (dwBytesPerSecIndex < _countof(aWMAAvgBytesPerSec))
+                    if (dwBytesPerSecIndex < 7)
                         return aWMAAvgBytesPerSec[dwBytesPerSecIndex];
                 }
                 break;
@@ -224,17 +224,17 @@ namespace
 
     struct BANKDATA
     {
-        static const size_t BANKNAME_LENGTH = 64;
+        static constexpr size_t BANKNAME_LENGTH = 64;
 
-        static const uint32_t TYPE_BUFFER = 0x00000000;
-        static const uint32_t TYPE_STREAMING = 0x00000001;
-        static const uint32_t TYPE_MASK = 0x00000001;
+        static constexpr uint32_t TYPE_BUFFER = 0x00000000;
+        static constexpr uint32_t TYPE_STREAMING = 0x00000001;
+        static constexpr uint32_t TYPE_MASK = 0x00000001;
 
-        static const uint32_t FLAGS_ENTRYNAMES = 0x00010000;
-        static const uint32_t FLAGS_COMPACT = 0x00020000;
-        static const uint32_t FLAGS_SYNC_DISABLED = 0x00040000;
-        static const uint32_t FLAGS_SEEKTABLES = 0x00080000;
-        static const uint32_t FLAGS_MASK = 0x000F0000;
+        static constexpr uint32_t FLAGS_ENTRYNAMES = 0x00010000;
+        static constexpr uint32_t FLAGS_COMPACT = 0x00020000;
+        static constexpr uint32_t FLAGS_SYNC_DISABLED = 0x00040000;
+        static constexpr uint32_t FLAGS_SEEKTABLES = 0x00080000;
+        static constexpr uint32_t FLAGS_MASK = 0x000F0000;
 
         uint32_t        dwFlags;                        // Bank flags
         uint32_t        dwEntryCount;                   // Number of entries in the bank
@@ -248,11 +248,11 @@ namespace
 
     struct ENTRY
     {
-        static const uint32_t FLAGS_READAHEAD = 0x00000001;     // Enable stream read-ahead
-        static const uint32_t FLAGS_LOOPCACHE = 0x00000002;     // One or more looping sounds use this wave
-        static const uint32_t FLAGS_REMOVELOOPTAIL = 0x00000004;// Remove data after the end of the loop region
-        static const uint32_t FLAGS_IGNORELOOP = 0x00000008;    // Used internally when the loop region can't be used
-        static const uint32_t FLAGS_MASK = 0x00000008;
+        static constexpr uint32_t FLAGS_READAHEAD = 0x00000001;     // Enable stream read-ahead
+        static constexpr uint32_t FLAGS_LOOPCACHE = 0x00000002;     // One or more looping sounds use this wave
+        static constexpr uint32_t FLAGS_REMOVELOOPTAIL = 0x00000004;// Remove data after the end of the loop region
+        static constexpr uint32_t FLAGS_IGNORELOOP = 0x00000008;    // Used internally when the loop region can't be used
+        static constexpr uint32_t FLAGS_MASK = 0x00000008;
 
         union
         {
@@ -495,7 +495,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     BOOL result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
-        (void)WaitForSingleObject(m_event.get(), INFINITE);
+        std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
 
     BOOL result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -539,7 +539,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
-        (void)WaitForSingleObject(m_event.get(), INFINITE);
+        std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -620,7 +620,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
             result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
         #else
             if (wait)
-                (void)WaitForSingleObject(m_event.get(), INFINITE);
+                std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
 
             result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
         #endif
@@ -671,7 +671,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
-        (void)WaitForSingleObject(m_event.get(), INFINITE);
+        std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -706,7 +706,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
         result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
     #else
         if (wait)
-            (void)WaitForSingleObject(m_event.get(), INFINITE);
+            std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
 
         result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
     #endif
@@ -807,11 +807,11 @@ void WaveBankReader::Impl::Close() noexcept
         {
             DWORD bytes;
         #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-            (void)GetOverlappedResultEx(m_async, &m_request, &bytes, INFINITE, FALSE);
+            std::ignore = GetOverlappedResultEx(m_async, &m_request, &bytes, INFINITE, FALSE);
         #else
-            (void)WaitForSingleObject(m_request.hEvent, INFINITE);
+            std::ignore = WaitForSingleObject(m_request.hEvent, INFINITE);
 
-            (void)GetOverlappedResult(m_async, &m_request, &bytes, FALSE);
+            std::ignore = GetOverlappedResult(m_async, &m_request, &bytes, FALSE);
         #endif
         }
 
@@ -1113,7 +1113,7 @@ void WaveBankReader::WaitOnPrepare() noexcept
 
     if (pImpl->m_request.hEvent)
     {
-        (void)WaitForSingleObjectEx(pImpl->m_request.hEvent, INFINITE, FALSE);
+        std::ignore = WaitForSingleObjectEx(pImpl->m_request.hEvent, INFINITE, FALSE);
 
         pImpl->UpdatePrepared();
     }
@@ -1181,4 +1181,10 @@ HRESULT WaveBankReader::GetMetadata(uint32_t index, Metadata& metadata) const no
 HANDLE WaveBankReader::GetAsyncHandle() const noexcept
 {
     return (pImpl->m_data.dwFlags & BANKDATA::TYPE_STREAMING) ? pImpl->m_async : INVALID_HANDLE_VALUE;
+}
+
+
+uint32_t WaveBankReader::GetWaveAlignment() const noexcept
+{
+    return pImpl->m_data.dwAlignment;
 }

--- a/XAudio2/Common/WaveBankReader.h
+++ b/XAudio2/Common/WaveBankReader.h
@@ -4,7 +4,6 @@
 // Functions for loading audio data from Wave Banks
 //
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License (MIT).
 // Licensed under the MIT License.
 //
 // http://go.microsoft.com/fwlink/?LinkId=248929
@@ -58,6 +57,8 @@ namespace DirectX
         HRESULT GetSeekTable(_In_ uint32_t index, _Out_ const uint32_t** pData, _Out_ uint32_t& dataCount, _Out_ uint32_t& tag) const noexcept;
 
         HANDLE GetAsyncHandle() const noexcept;
+
+        uint32_t GetWaveAlignment() const noexcept;
 
         struct Metadata
         {

--- a/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_2019_Win10.vcxproj
+++ b/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_2019_Win10.vcxproj
@@ -154,9 +154,6 @@
     <ClInclude Include="..\Common\WaveBankReader.h" />
     <ClInclude Include="..\Common\XAudio2Versions.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="ClassDiagram.cd" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_2019_Win10.vcxproj.filters
+++ b/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_2019_Win10.vcxproj.filters
@@ -8,7 +8,4 @@
     <ClInclude Include="..\Common\WaveBankReader.h" />
     <ClInclude Include="..\Common\XAudio2Versions.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="ClassDiagram.cd" />
-  </ItemGroup>
 </Project>

--- a/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_NuGetRedist_2019.vcxproj
+++ b/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_NuGetRedist_2019.vcxproj
@@ -153,7 +153,6 @@
     <ClInclude Include="..\Common\XAudio2Versions.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ClassDiagram.cd" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_NuGetRedist_2019.vcxproj.filters
+++ b/XAudio2/XAudio2AsyncStream/XAudio2AsyncStream_NuGetRedist_2019.vcxproj.filters
@@ -9,7 +9,6 @@
     <ClInclude Include="..\Common\XAudio2Versions.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ClassDiagram.cd" />
     <None Include="packages.config" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
XAudio2 wavebank streaming sample updated to support Advanced Format (4Kn) format drives which have a 4096 sector size vs. the classic 2048 that worked for DVDs, older generation HDDs, and Advanced Format drives in 512e mode.
