### PR TITLE
Fixed link to MSDN article of Direct3D11Tutorials #7 not working.

### DIFF
--- a/Direct3D11Tutorials/README.md
+++ b/Direct3D11Tutorials/README.md
@@ -84,7 +84,7 @@ In the previous tutorial, we introduced lighting to our project. Now we will bui
 The purpose of this tutorial is to modify the center cube to have a texture mapped onto it. 
 
  
-http://msdn.microsoft.com/en-us/library/windows/apps/ff729724.aspx 
+http://msdn.microsoft.com/en-us/library/windows/apps/ff729724.aspx
 
 Note rather than use the deprecated D3DX11 library to load the texture as was used in the original tutorial, this version uses the included DDSTextureLoader module.
 


### PR DESCRIPTION
There was an additional  trailing whitespace after the link compared to the ones for 1-6 which were working. Removed the trailing whitespace made the link work again.